### PR TITLE
Make aws kms client use proxy

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,5 @@
 workspace(name = "tink_base")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 load("@tink_base//:tink_base_deps.bzl", "tink_base_deps")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,4 @@
 workspace(name = "tink_base")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 load("@tink_base//:tink_base_deps.bzl", "tink_base_deps")
 

--- a/cc/integration/awskms/aws_kms_client.cc
+++ b/cc/integration/awskms/aws_kms_client.cc
@@ -200,11 +200,13 @@ AwsKmsClient::New(absl::string_view key_uri,
     }
     auto config_result = GetAwsClientConfig(client->key_arn_);
     if (!config_result.ok()) return config_result.status();
+    client->config_ = config_result.ValueOrDie();
+
     // Create AWS KMSClient.
     client->aws_client_ = Aws::MakeShared<Aws::KMS::KMSClient>(
         kAwsCryptoAllocationTag,
         client->credentials_,
-        config_result.ValueOrDie());
+        client->config_);
   }
   return std::move(client);
 }
@@ -214,6 +216,10 @@ bool AwsKmsClient::DoesSupport(absl::string_view key_uri) const {
     return key_arn_ == GetKeyArn(key_uri);
   }
   return !GetKeyArn(key_uri).empty();
+}
+
+Aws::Client::ClientConfiguration AwsKmsClient::GetConfig() const {
+  return config_;
 }
 
 StatusOr<std::unique_ptr<Aead>>

--- a/cc/integration/awskms/aws_kms_client.cc
+++ b/cc/integration/awskms/aws_kms_client.cc
@@ -70,6 +70,11 @@ StatusOr<Aws::Client::ClientConfiguration>
   config.scheme = Aws::Http::Scheme::HTTPS;
   config.connectTimeoutMs = 30000;
   config.requestTimeoutMs = 60000;
+  config.proxyUserName = std::getenv("PROXY_USERNAME");
+  config.proxyPassword = std::getenv("PROXY_PASSWORD");
+  config.proxyHost = std::getenv("PROXY_HOST");
+  config.proxyPort = atoi(std::getenv("PROXY_PORT"));
+  config.proxyScheme = Aws::Http::Scheme::HTTP;
   return config;
 }
 

--- a/cc/integration/awskms/aws_kms_client.cc
+++ b/cc/integration/awskms/aws_kms_client.cc
@@ -70,11 +70,6 @@ StatusOr<Aws::Client::ClientConfiguration>
   config.scheme = Aws::Http::Scheme::HTTPS;
   config.connectTimeoutMs = 30000;
   config.requestTimeoutMs = 60000;
-  config.proxyUserName = std::getenv("PROXY_USERNAME");
-  config.proxyPassword = std::getenv("PROXY_PASSWORD");
-  config.proxyHost = std::getenv("PROXY_HOST");
-  config.proxyPort = atoi(std::getenv("PROXY_PORT"));
-  config.proxyScheme = Aws::Http::Scheme::HTTP;
   return config;
 }
 

--- a/cc/integration/awskms/aws_kms_client.h
+++ b/cc/integration/awskms/aws_kms_client.h
@@ -58,6 +58,9 @@ class AwsKmsClient : public crypto::tink::KmsClient  {
   crypto::tink::util::StatusOr<std::unique_ptr<Aead>>
   GetAead(absl::string_view key_uri) const override;
 
+  // Returns the config used to create the client
+  Aws::Client::ClientConfiguration GetConfig() const;
+
  private:
   AwsKmsClient() {}
   // Initializes AWS API.
@@ -67,6 +70,7 @@ class AwsKmsClient : public crypto::tink::KmsClient  {
 
   std::string key_arn_;
   Aws::Auth::AWSCredentials credentials_;
+  Aws::Client::ClientConfiguration config_;
   std::shared_ptr<Aws::KMS::KMSClient> aws_client_;
 };
 

--- a/cc/integration/awskms/aws_kms_client_test.cc
+++ b/cc/integration/awskms/aws_kms_client_test.cc
@@ -86,6 +86,21 @@ TEST(AwsKmsClientTest, ClientCreationInvalidRegistry) {
   EXPECT_THAT(client_result, StatusIs(util::error::INVALID_ARGUMENT));
 }
 
+TEST(AwsKmsClientTest, ConfigCreation) {
+  std::string aws_key = "aws-kms://arn:aws:kms:us-east-1:acc:some/key1";
+  std::string creds_file = absl::StrCat(
+      getenv("TEST_SRCDIR"), "/tink_base/testdata/aws_credentials_cc.txt");
+
+  auto client_result = AwsKmsClient::New(aws_key, creds_file);
+  EXPECT_THAT(client_result.status(), IsOk());
+
+  auto config = client_result.ValueOrDie()->GetConfig();
+  EXPECT_EQ("us-east-1", config.region);
+  EXPECT_EQ(Aws::Http::Scheme::HTTPS, config.scheme);
+  EXPECT_EQ(30000, config.connectTimeoutMs);
+  EXPECT_EQ(60000, config.requestTimeoutMs);
+}
+
 }  // namespace
 }  // namespace awskms
 }  // namespace integration


### PR DESCRIPTION
Addresses the proxy aspect of [this issue](https://github.com/google/tink/issues/485).

I'm not familiar with c++ so very open to suggestions!

Gosh [there are a lot of proxy environment variable variations](https://stackoverflow.com/q/58559109). I'm just getting it working for the following variations now:

HTTPS_PROXY=https://username:password@someproxy.host:1234
HTTPS_PROXY=https://someproxy.host:1234
HTTPS_PROXY=http://username:password@someproxy.host:1234
HTTPS_PROXY=http://someproxy.host:1234

TODO
- [ ] make sure it works also for HTTPS_PROXY=host:port

Thx